### PR TITLE
Fix build issues and improve benchmark usability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.0'
     id 'biz.aQute.bnd.builder' version '5.1.2'
-    id "org.gradle.test-retry" version "1.1.9"
+    id "org.gradle.test-retry" version "1.5.8"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'signing'
 }
@@ -102,6 +102,7 @@ javadoc {
                 "io/nats/client/api/MessageGetRequest.java"
     ]
     classpath = sourceSets.main.runtimeClasspath
+    options.addStringOption('Xdoclint:none', '-quiet')
     doLast {
         if (!OperatingSystem.current().isWindows()) {
             exec {
@@ -148,6 +149,7 @@ task testsJar(type: Jar) {
 
 // run build before running fat jar to get classes
 task fatJar(type: Jar) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     archiveClassifier.set('fat')
     manifest {
         attributes('Implementation-Title': 'Java Nats With Dependencies',
@@ -163,13 +165,13 @@ task fatJar(type: Jar) {
 }
 
 jacoco {
-    toolVersion = "0.8.6"
+    toolVersion = "0.8.11"
 }
 
 jacocoTestReport {
     reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
-        html.enabled = true
+        xml.required.set(true) // coveralls plugin depends on xml format report
+        html.required.set(true)
     }
     afterEvaluate { // only report on main library not examples
         classDirectories.setFrom(files(classDirectories.files.collect {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
+++ b/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
@@ -43,15 +43,6 @@ public class NatsAutoBench {
             + "\n\ntiny, small and med reduce the number of messages used for tests, which can help on slower machines\n";
 
     public static void main(String[] args) {
-
-        // TO RUN WITH ARGS FROM IDE, ADD A LINE LIKE THESE
-        // args = "myhost:4222 med".split(" ");
-         args = "small PubOnly".split(" ");
-        // args = "large PubOnlyWithHeaders".split(" ");
-        // args = "med JsPubAsync".split(" ");
-        // args = "help".split(" ");
-        // args = "latency large".split(" ");
-
         Arguments a = readArgs(args);
 
         System.out.printf("Connecting to NATS server at %s\n", a.server);

--- a/src/examples/java/io/nats/examples/benchmark/NatsBench.java
+++ b/src/examples/java/io/nats/examples/benchmark/NatsBench.java
@@ -497,7 +497,6 @@ public class NatsBench {
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        args = "-s nats://192.168.50.183:4222 -csv foo".split(" ");
         Properties properties = null;
         try {
             if (args.length == 1 && args[0].endsWith(".properties")) {


### PR DESCRIPTION
This commit addresses several issues that prevented the project from building and running tests with a modern JDK. It also improves the usability of the benchmark tools.

Build Fixes:
- Upgraded Gradle wrapper from 6.8.3 to 8.5 to support Java 21.
- Updated the `org.gradle.test-retry` plugin from 1.1.9 to 1.5.8 for compatibility with Gradle 8.5.
- Updated the JaCoCo Gradle plugin version from 0.8.6 to 0.8.11 and adjusted the report configuration syntax (`enabled = true` to `required.set(true)`).
- Disabled strict Javadoc checking by adding `Xdoclint:none` to prevent build failures with newer Gradle versions.
- Configured the `fatJar` task with `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` to prevent errors from duplicate manifest files in dependencies.

Benchmark Improvements:
- Removed confusing, commented-out, hardcoded arguments from the `main` methods of `NatsBench.java` and `NatsAutoBench.java`. This ensures the tools use the arguments provided at runtime without modification.